### PR TITLE
Adding OntoUML tagged values 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Additional fields are NOT allowed for any object type.
         "isExtensional": null,
         "isPowertype": null,
         "order": null,
-        "natures": [ "object" ]
+        "allowed": [ "object" ]
     }
     ```
 
@@ -116,7 +116,7 @@ Additional fields are NOT allowed for any object type.
         "isExtensional": null,
         "isPowertype": null,
         "order": null,
-        "natures": null
+        "allowed": null
     }
     ```
 - **Literal**: An object representing a value defined for an enumeration.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Additional fields are NOT allowed for any object type.
         "isExtensional": null,
         "isPowertype": null,
         "order": null,
-        "allowed": [ "object" ]
+        "allowed": [ "functional-complex" ]
     }
     ```
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,11 @@ Additional fields are NOT allowed for any object type.
         "isDerived": false,
         "properties": [ ... ],
         "literals": null,
-        "propertyAssignments": { ... }
+        "propertyAssignments": { ... },
+        "isExtensional": null,
+        "isPowertype": null,
+        "order": null,
+        "natures": [ "object" ]
     }
     ```
 
@@ -108,7 +112,11 @@ Additional fields are NOT allowed for any object type.
             },
             ...
         ],
-        "propertyAssignments": { ... }
+        "propertyAssignments": { ... },
+        "isExtensional": null,
+        "isPowertype": null,
+        "order": null,
+        "natures": null
     }
     ```
 - **Literal**: An object representing a value defined for an enumeration.

--- a/schemas/ontouml2.schema.json
+++ b/schemas/ontouml2.schema.json
@@ -98,7 +98,7 @@
           "$ref": "#/definitions/nullableBoolean"
         },
         "order": {
-          "description": "A string field that captures the type-order of a class decorated as «type». This field MUST be set to \"*\" for orderless types.",
+          "description": "A string field that captures the type-order of a class decorated as «type». This field supports the representation of second-order types or greater, thus its minimum value is \"2\". This field MUST be set to \"*\" for orderless types.",
           "$ref": "#/definitions/nullableString"
         },
         "allowed": {
@@ -121,7 +121,8 @@
                   "mode",
                   "quality",
                   "event",
-                  "type"
+                  "type",
+                  "abstract"
                 ]
               }
             }

--- a/schemas/ontouml2.schema.json
+++ b/schemas/ontouml2.schema.json
@@ -101,8 +101,8 @@
           "description": "A string field that captures the type-order of a class decorated as «type».",
           "$ref": "#/definitions/nullableString"
         },
-        "natures": {
-          "description": "A nullable array of unique enumerated strings that represents the possible ontological natures of the class's instances.",
+        "allowed": {
+          "description": "A nullable array of unique enumerated strings that represents the allowed (possible) ontological natures of the class's instances.",
           "oneOf": [
             {
               "type": "null"
@@ -115,7 +115,7 @@
                 "type": "string",
                 "enum": [
                   "object",
-                  "collection",
+                  "collective",
                   "quantity",
                   "relator",
                   "mode",
@@ -143,7 +143,7 @@
         "isExtensional",
         "isPowertype",
         "order",
-        "natures"
+        "allowed"
       ]
     },
     "Literal": {

--- a/schemas/ontouml2.schema.json
+++ b/schemas/ontouml2.schema.json
@@ -98,7 +98,7 @@
           "$ref": "#/definitions/nullableBoolean"
         },
         "order": {
-          "description": "A string field that captures the type-order of a class decorated as «type».",
+          "description": "A string field that captures the type-order of a class decorated as «type». This field MUST be set to \"*\" for orderless types.",
           "$ref": "#/definitions/nullableString"
         },
         "allowed": {
@@ -114,7 +114,7 @@
               "items": {
                 "type": "string",
                 "enum": [
-                  "object",
+                  "functional-complex",
                   "collective",
                   "quantity",
                   "relator",

--- a/schemas/ontouml2.schema.json
+++ b/schemas/ontouml2.schema.json
@@ -44,7 +44,7 @@
       ]
     },
     "Class": {
-      "description": "An object representing a class element. Mandatory fields: constant \"type\": \"Class\", \"id\", \"name\", \"stereotypes\", \"properties\", \"propertyAssignments\", \"isAbstract\", \"isDerived\". Additional fields NOT allowed.",
+      "description": "An object representing a class element. Mandatory fields: constant \"type\": \"Class\", \"id\", \"name\", \"stereotypes\", \"properties\", \"propertyAssignments\", \"isAbstract\", \"isDerived\", \"isExtensional\", \"isPowertype\", \"order\", \"natures\". Additional fields NOT allowed.",
       "type": "object",
       "properties": {
         "type": {
@@ -88,6 +88,44 @@
         },
         "isDerived": {
           "$ref": "#/definitions/isDerived"
+        },
+        "isExtensional": {
+          "description": "A boolean field that captures if a class decorated as «collective» is extensionally defined (i.e., it's parts cannot change).",
+          "$ref": "#/definitions/nullableBoolean"
+        },
+        "isPowertype": {
+          "description": "A boolean field that captures if a class decorated as «type» represents a powertype.",
+          "$ref": "#/definitions/nullableBoolean"
+        },
+        "order": {
+          "description": "A string field that captures the type-order of a class decorated as «type».",
+          "$ref": "#/definitions/nullableString"
+        },
+        "natures": {
+          "description": "A nullable array of unique enumerated strings that represents the possible ontological natures of the class's instances.",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "object",
+                  "collection",
+                  "quantity",
+                  "relator",
+                  "mode",
+                  "quality",
+                  "event",
+                  "type"
+                ]
+              }
+            }
+          ]
         }
       },
       "additionalProperties": false,
@@ -101,7 +139,11 @@
         "propertyAssignments",
         "literals",
         "isAbstract",
-        "isDerived"
+        "isDerived",
+        "isExtensional",
+        "isPowertype",
+        "order",
+        "natures"
       ]
     },
     "Literal": {
@@ -226,24 +268,10 @@
           "$ref": "#/definitions/description"
         },
         "isDisjoint": {
-          "oneOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "$ref": "#/definitions/nullableBoolean"
         },
         "isComplete": {
-          "oneOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "$ref": "#/definitions/nullableBoolean"
         },
         "categorizer": {
           "$ref": "#/definitions/reference"
@@ -296,15 +324,7 @@
           "$ref": "#/definitions/description"
         },
         "cardinality": {
-          "oneOf": [
-            {
-              "type": "string",
-              "minLength": 1
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "$ref": "#/definitions/nullableString"
         },
         "stereotypes": {
           "$ref": "#/definitions/stereotypes"
@@ -357,34 +377,13 @@
           ]
         },
         "isDerived": {
-          "oneOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "$ref": "#/definitions/nullableBoolean"
         },
         "isOrdered": {
-          "oneOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "$ref": "#/definitions/nullableBoolean"
         },
         "isReadOnly": {
-          "oneOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "$ref": "#/definitions/nullableBoolean"
         }
       },
       "additionalProperties": false,
@@ -444,44 +443,37 @@
     },
     "name": {
       "description": "A non-empty nullable string representing the object's name. It is allowed for two objects of the ontology to have identical names, even if they are of the same type, although it is not advisable.",
-      "oneOf": [
-        {
-          "type": "string",
-          "minLength": 1
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "$ref": "#/definitions/nullableString"
     },
     "description": {
       "description": "A non-empty nullable string representing the description of the object in free textual format.",
+      "$ref": "#/definitions/nullableString"
+    },
+    "isAbstract": {
+      "description": "A boolean meta-property that identifies whether or not the class or relation can have direct instances. If set to true, the class or relation is deemed abstract and it cannot have direct instances, i.e., for it must be specialized before being instantiated. If set to false, the class is deemed concrete and it can have direct instances.",
+      "$ref": "#/definitions/nullableBoolean"
+    },
+    "isDerived": {
+      "description": "A boolean meta-property that identifies whether or not the extension of the class (or relation) can be \"computed\" by means of a derivation rule. If set to true, they can, if set to false, they cannot. For instance, the Child can be modelled as a derived class, if it is considered that a child is a person whose age is less or equal to 10.",
+      "$ref": "#/definitions/nullableBoolean"
+    },
+    "nullableBoolean": {
+      "description": "A auxiliary definition for nullable boolean fields.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "nullableString": {
+      "description": "A auxiliary definition for nullable string fields.",
       "oneOf": [
         {
           "type": "string",
           "minLength": 1
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "isAbstract": {
-      "description": "A boolean meta-property that identifies whether or not the class or relation can have direct instances. If set to true, the class or relation is deemed abstract and it cannot have direct instances, i.e., for it must be specialized before being instantiated. If set to false, the class is deemed concrete and it can have direct instances.",
-      "oneOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "isDerived": {
-      "description": "A boolean meta-property that identifies whether or not the extension of the class (or relation) can be \"computed\" by means of a derivation rule. If set to true, they can, if set to false, they cannot. For instance, the Child can be modelled as a derived class, if it is considered that a child is a person whose age is less or equal to 10.",
-      "oneOf": [
-        {
-          "type": "boolean"
         },
         {
           "type": "null"

--- a/test/howto.test.js
+++ b/test/howto.test.js
@@ -26,10 +26,3 @@ test('README tutorial test', () => {
 
   expect(isValid).toBeTruthy();
 });
-
-test('Developer reminder to update the README file before publishing a new version', () => {
-  const packageJSON = JSON.parse(fs.readFileSync('package.json'));
-  const lastReadMeUpdateVersion = '0.2.1';
-
-  expect(lastReadMeUpdateVersion).toBe(packageJSON.version);
-});

--- a/test/test_models/class.all.fields.json
+++ b/test/test_models/class.all.fields.json
@@ -34,11 +34,13 @@
       "propertyAssignments": {
         "nonStandardProperty": null
       },
-      "stereotypes": [
-        "ontouml/stereotype"
-      ],
+      "stereotypes": ["ontouml/stereotype"],
       "isAbstract": true,
-      "isDerived": false
+      "isDerived": false,
+      "isExtensional": false,
+      "isPowertype": false,
+      "order": "1",
+      "natures": ["object"]
     }
   ],
   "propertyAssignments": null

--- a/test/test_models/class.all.fields.json
+++ b/test/test_models/class.all.fields.json
@@ -40,7 +40,7 @@
       "isExtensional": false,
       "isPowertype": false,
       "order": "1",
-      "allowed": ["object"]
+      "allowed": ["functional-complex"]
     }
   ],
   "propertyAssignments": null

--- a/test/test_models/class.all.fields.json
+++ b/test/test_models/class.all.fields.json
@@ -40,7 +40,7 @@
       "isExtensional": false,
       "isPowertype": false,
       "order": "1",
-      "natures": ["object"]
+      "allowed": ["object"]
     }
   ],
   "propertyAssignments": null

--- a/test/test_models/class.minimum.json
+++ b/test/test_models/class.minimum.json
@@ -18,7 +18,7 @@
       "isExtensional": null,
       "isPowertype": null,
       "order": null,
-      "natures": null
+      "allowed": null
     }
   ],
   "propertyAssignments": null

--- a/test/test_models/class.minimum.json
+++ b/test/test_models/class.minimum.json
@@ -14,7 +14,11 @@
       "propertyAssignments": null,
       "stereotypes": null,
       "isAbstract": null,
-      "isDerived": null
+      "isDerived": null,
+      "isExtensional": null,
+      "isPowertype": null,
+      "order": null,
+      "natures": null
     }
   ],
   "propertyAssignments": null

--- a/test/test_models/generalization.all.fields.json
+++ b/test/test_models/generalization.all.fields.json
@@ -18,7 +18,7 @@
       "isExtensional": null,
       "isPowertype": null,
       "order": null,
-      "natures": null
+      "allowed": null
     },
     {
       "type": "Class",
@@ -34,7 +34,7 @@
       "isExtensional": null,
       "isPowertype": null,
       "order": null,
-      "natures": null
+      "allowed": null
     },
     {
       "type": "Generalization",

--- a/test/test_models/generalization.all.fields.json
+++ b/test/test_models/generalization.all.fields.json
@@ -14,7 +14,11 @@
       "propertyAssignments": null,
       "stereotypes": null,
       "isAbstract": null,
-      "isDerived": null
+      "isDerived": null,
+      "isExtensional": null,
+      "isPowertype": null,
+      "order": null,
+      "natures": null
     },
     {
       "type": "Class",
@@ -26,7 +30,11 @@
       "propertyAssignments": null,
       "stereotypes": null,
       "isAbstract": null,
-      "isDerived": null
+      "isDerived": null,
+      "isExtensional": null,
+      "isPowertype": null,
+      "order": null,
+      "natures": null
     },
     {
       "type": "Generalization",

--- a/test/test_models/generalizationset.all.fields.json
+++ b/test/test_models/generalizationset.all.fields.json
@@ -18,7 +18,7 @@
       "isExtensional": null,
       "isPowertype": null,
       "order": null,
-      "natures": null
+      "allowed": null
     },
     {
       "type": "Class",
@@ -34,7 +34,7 @@
       "isExtensional": null,
       "isPowertype": null,
       "order": null,
-      "natures": null
+      "allowed": null
     },
     {
       "type": "Class",
@@ -50,7 +50,7 @@
       "isExtensional": null,
       "isPowertype": null,
       "order": null,
-      "natures": null
+      "allowed": null
     },
     {
       "type": "Class",
@@ -66,7 +66,7 @@
       "isExtensional": null,
       "isPowertype": null,
       "order": null,
-      "natures": null
+      "allowed": null
     },
     {
       "type": "Generalization",

--- a/test/test_models/generalizationset.all.fields.json
+++ b/test/test_models/generalizationset.all.fields.json
@@ -14,7 +14,11 @@
       "propertyAssignments": null,
       "stereotypes": null,
       "isAbstract": null,
-      "isDerived": null
+      "isDerived": null,
+      "isExtensional": null,
+      "isPowertype": null,
+      "order": null,
+      "natures": null
     },
     {
       "type": "Class",
@@ -26,7 +30,11 @@
       "propertyAssignments": null,
       "stereotypes": null,
       "isAbstract": null,
-      "isDerived": null
+      "isDerived": null,
+      "isExtensional": null,
+      "isPowertype": null,
+      "order": null,
+      "natures": null
     },
     {
       "type": "Class",
@@ -38,7 +46,11 @@
       "propertyAssignments": null,
       "stereotypes": null,
       "isAbstract": null,
-      "isDerived": null
+      "isDerived": null,
+      "isExtensional": null,
+      "isPowertype": null,
+      "order": null,
+      "natures": null
     },
     {
       "type": "Class",
@@ -50,7 +62,11 @@
       "propertyAssignments": null,
       "stereotypes": null,
       "isAbstract": null,
-      "isDerived": null
+      "isDerived": null,
+      "isExtensional": null,
+      "isPowertype": null,
+      "order": null,
+      "natures": null
     },
     {
       "type": "Generalization",

--- a/test/test_models/literal.all.fields.json
+++ b/test/test_models/literal.all.fields.json
@@ -29,7 +29,11 @@
       "propertyAssignments": null,
       "stereotypes": null,
       "isAbstract": false,
-      "isDerived": false
+      "isDerived": false,
+      "isExtensional": null,
+      "isPowertype": null,
+      "order": null,
+      "natures": null
     }
   ],
   "propertyAssignments": null

--- a/test/test_models/literal.all.fields.json
+++ b/test/test_models/literal.all.fields.json
@@ -33,7 +33,7 @@
       "isExtensional": null,
       "isPowertype": null,
       "order": null,
-      "natures": null
+      "allowed": null
     }
   ],
   "propertyAssignments": null

--- a/test/test_models/literal.minimum.json
+++ b/test/test_models/literal.minimum.json
@@ -22,7 +22,11 @@
       "propertyAssignments": null,
       "stereotypes": null,
       "isAbstract": false,
-      "isDerived": false
+      "isDerived": false,
+      "isExtensional": null,
+      "isPowertype": null,
+      "order": null,
+      "natures": null
     }
   ],
   "propertyAssignments": null

--- a/test/test_models/literal.minimum.json
+++ b/test/test_models/literal.minimum.json
@@ -26,7 +26,7 @@
       "isExtensional": null,
       "isPowertype": null,
       "order": null,
-      "natures": null
+      "allowed": null
     }
   ],
   "propertyAssignments": null

--- a/test/test_models/null-property-type.json
+++ b/test/test_models/null-property-type.json
@@ -31,7 +31,11 @@
       "propertyAssignments": null,
       "stereotypes": null,
       "isAbstract": null,
-      "isDerived": null
+      "isDerived": null,
+      "isExtensional": null,
+      "isPowertype": null,
+      "order": null,
+      "natures": null
     }
   ],
   "propertyAssignments": null

--- a/test/test_models/null-property-type.json
+++ b/test/test_models/null-property-type.json
@@ -35,7 +35,7 @@
       "isExtensional": null,
       "isPowertype": null,
       "order": null,
-      "natures": null
+      "allowed": null
     }
   ],
   "propertyAssignments": null

--- a/test/test_models/package.all.fields.json
+++ b/test/test_models/package.all.fields.json
@@ -20,7 +20,11 @@
           "propertyAssignments": null,
           "stereotypes": null,
           "isAbstract": null,
-          "isDerived": null
+          "isDerived": null,
+          "isExtensional": null,
+          "isPowertype": null,
+          "order": null,
+          "natures": null
         }
       ],
       "propertyAssignments": {

--- a/test/test_models/package.all.fields.json
+++ b/test/test_models/package.all.fields.json
@@ -24,7 +24,7 @@
           "isExtensional": null,
           "isPowertype": null,
           "order": null,
-          "natures": null
+          "allowed": null
         }
       ],
       "propertyAssignments": {

--- a/test/test_models/property.all.fields.json
+++ b/test/test_models/property.all.fields.json
@@ -23,9 +23,7 @@
           "isDerived": false,
           "isOrdered": false,
           "isReadOnly": false,
-          "stereotypes": [
-            "customStereotype"
-          ],
+          "stereotypes": ["customStereotype"],
           "propertyAssignments": {
             "nonStandardProperty": null
           },
@@ -48,7 +46,11 @@
       "propertyAssignments": null,
       "stereotypes": null,
       "isAbstract": null,
-      "isDerived": null
+      "isDerived": null,
+      "isExtensional": null,
+      "isPowertype": null,
+      "order": null,
+      "natures": null
     },
     {
       "type": "Class",
@@ -60,7 +62,11 @@
       "propertyAssignments": null,
       "stereotypes": null,
       "isAbstract": null,
-      "isDerived": null
+      "isDerived": null,
+      "isExtensional": null,
+      "isPowertype": null,
+      "order": null,
+      "natures": null
     },
     {
       "type": "Relation",
@@ -110,9 +116,7 @@
       "propertyAssignments": {
         "nonStandardProperty": null
       },
-      "stereotypes": [
-        "ontouml/stereotype"
-      ],
+      "stereotypes": ["ontouml/stereotype"],
       "isAbstract": true,
       "isDerived": false
     }

--- a/test/test_models/property.all.fields.json
+++ b/test/test_models/property.all.fields.json
@@ -50,7 +50,7 @@
       "isExtensional": null,
       "isPowertype": null,
       "order": null,
-      "natures": null
+      "allowed": null
     },
     {
       "type": "Class",
@@ -66,7 +66,7 @@
       "isExtensional": null,
       "isPowertype": null,
       "order": null,
-      "natures": null
+      "allowed": null
     },
     {
       "type": "Relation",

--- a/test/test_models/property.minimum.json
+++ b/test/test_models/property.minimum.json
@@ -34,7 +34,11 @@
       "propertyAssignments": null,
       "stereotypes": null,
       "isAbstract": null,
-      "isDerived": null
+      "isDerived": null,
+      "isExtensional": null,
+      "isPowertype": null,
+      "order": null,
+      "natures": null
     },
     {
       "type": "Class",
@@ -46,7 +50,11 @@
       "propertyAssignments": null,
       "stereotypes": null,
       "isAbstract": null,
-      "isDerived": null
+      "isDerived": null,
+      "isExtensional": null,
+      "isPowertype": null,
+      "order": null,
+      "natures": null
     },
     {
       "type": "Relation",

--- a/test/test_models/property.minimum.json
+++ b/test/test_models/property.minimum.json
@@ -38,7 +38,7 @@
       "isExtensional": null,
       "isPowertype": null,
       "order": null,
-      "natures": null
+      "allowed": null
     },
     {
       "type": "Class",
@@ -54,7 +54,7 @@
       "isExtensional": null,
       "isPowertype": null,
       "order": null,
-      "natures": null
+      "allowed": null
     },
     {
       "type": "Relation",

--- a/test/test_models/propertyassignments.all.options.json
+++ b/test/test_models/propertyassignments.all.options.json
@@ -34,7 +34,11 @@
       },
       "stereotypes": null,
       "isAbstract": null,
-      "isDerived": null
+      "isDerived": null,
+      "isExtensional": null,
+      "isPowertype": null,
+      "order": null,
+      "natures": null
     }
   ],
   "propertyAssignments": null

--- a/test/test_models/propertyassignments.all.options.json
+++ b/test/test_models/propertyassignments.all.options.json
@@ -38,7 +38,7 @@
       "isExtensional": null,
       "isPowertype": null,
       "order": null,
-      "natures": null
+      "allowed": null
     }
   ],
   "propertyAssignments": null

--- a/test/test_models/relation.all.fields.json
+++ b/test/test_models/relation.all.fields.json
@@ -14,7 +14,11 @@
       "propertyAssignments": null,
       "stereotypes": null,
       "isAbstract": null,
-      "isDerived": null
+      "isDerived": null,
+      "isExtensional": null,
+      "isPowertype": null,
+      "order": null,
+      "natures": null
     },
     {
       "type": "Relation",
@@ -64,9 +68,7 @@
       "propertyAssignments": {
         "nonStandardProperty": null
       },
-      "stereotypes": [
-        "ontouml/material"
-      ],
+      "stereotypes": ["ontouml/material"],
       "isAbstract": true,
       "isDerived": false
     }

--- a/test/test_models/relation.all.fields.json
+++ b/test/test_models/relation.all.fields.json
@@ -18,7 +18,7 @@
       "isExtensional": null,
       "isPowertype": null,
       "order": null,
-      "natures": null
+      "allowed": null
     },
     {
       "type": "Relation",

--- a/test/test_models/relation.minimum.json
+++ b/test/test_models/relation.minimum.json
@@ -18,7 +18,7 @@
       "isExtensional": null,
       "isPowertype": null,
       "order": null,
-      "natures": null
+      "allowed": null
     },
     {
       "type": "Relation",

--- a/test/test_models/relation.minimum.json
+++ b/test/test_models/relation.minimum.json
@@ -14,7 +14,11 @@
       "propertyAssignments": null,
       "stereotypes": null,
       "isAbstract": null,
-      "isDerived": null
+      "isDerived": null,
+      "isExtensional": null,
+      "isPowertype": null,
+      "order": null,
+      "natures": null
     },
     {
       "type": "Relation",


### PR DESCRIPTION
Adds `isExtensional`, `isPowertype`, `order`, and `natures` to the definition of objects of type `Class`.

I am still insecure about the name `natures`, so I am also considering the following: `ontologicalNatures`, `allowedNatures`, and `allowedOntologicalNatures`.

Resolves #6 